### PR TITLE
update thor gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     retscli (0.2.0)
       rets (~> 0.10)
       terminal-table (~> 1.5)
-      thor (~> 0.19)
+      thor
       tty-spinner (~> 0.2)
 
 GEM
@@ -28,7 +28,7 @@ GEM
       nokogiri (~> 1.5)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.20.3)
+    thor (1.2.2)
     tty-cursor (0.7.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)

--- a/retscli.gemspec
+++ b/retscli.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rets", "~> 0.10"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor"
   spec.add_dependency "terminal-table", "~> 1.5"
   spec.add_dependency "tty-spinner", "~> 0.2"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Rails 6.1 and the original retscli gem have incompatible thor gem versions. Here I forked the original retscli gem and update the thor gem which will allow us to upgrade Rails to 6.1